### PR TITLE
Added trade order annotations for charting

### DIFF
--- a/prophet/backtest.py
+++ b/prophet/backtest.py
@@ -80,21 +80,22 @@ def backtest(cash,
                                      prices=prices,
                                      cash=cash,
                                      portfolio=portfolio)
-
-        if len(orders) > 0:
-            ordersDict[timestamp] = orders
         
-        for order in orders:
-            # Get the price after slippage
-            price = prices[order.symbol].loc[timestamp]
-            if order.shares < 0:
-                adjusted_price = price * (1 - slippage)
-            else:
-                adjusted_price = price * (1 + slippage)
-
-            cash -= order.shares * adjusted_price
-            cash -= commission
-            portfolio_shares[order.symbol] += order.shares
+        if orders is not None:
+            if len(orders) > 0:
+                ordersDict[timestamp] = orders
+        
+            for order in orders:
+                # Get the price after slippage
+                price = prices[order.symbol].loc[timestamp]
+                if order.shares < 0:
+                    adjusted_price = price * (1 - slippage)
+                else:
+                    adjusted_price = price * (1 + slippage)
+    
+                cash -= order.shares * adjusted_price
+                cash -= commission
+                portfolio_shares[order.symbol] += order.shares
 
         # Calculate total portfolio value for current timestamp
         current_value = cash

--- a/prophet/charting.py
+++ b/prophet/charting.py
@@ -18,6 +18,20 @@ def visualize_backtest(backtest):
     axPV.set_yticklabels(["{:,}".format(int(x)) for x in axPV.get_yticks().tolist()])
     axPV.set_title("Portfolio Value", size=12)
     
+    #--------------------------------------------------------------------------------
+    # annotate axPV with order details if there are any
+    if backtest.ordersDict is not None:
+        ordersDict = backtest.ordersDict
+        for timestamp in ordersDict.keys():
+            orders = ordersDict[timestamp]
+            for order in orders:
+                symbol, shares, tstamp = order.symbol, order.shares, timestamp.to_pydatetime()
+                direction = "B" if shares > 0 else "S"
+                desc = "%s %d %s" % (direction, shares, symbol)
+                color = "g" if direction == "B" else "r"
+                axPV.plot(tstamp, backtest.loc[tstamp], "^", markersize=5, color=color)
+    #--------------------------------------------------------------------------------
+    
     axDrawdown.plot(backtest.index, pvDrawdown, color="red")
     axDrawdown.set_yticklabels(["{:3.0f}%".format(x*100) for x in axDrawdown.get_yticks().tolist()])
     axDrawdown.set_title("Drawdown", size=12)
@@ -27,4 +41,48 @@ def visualize_backtest(backtest):
     axNormed.set_title("Normalized Portfolio Value", size=12)
     
     fig.tight_layout()
+    
+    #--------------------------------------------------------------------------------
+    # now we chart the stock prices and trades (only where there is a trade for the stock)
+    if backtest.prices is not None:
+        prices = backtest.prices
+        
+        stocks = []
+        for orders in ordersDict.values():
+            for order in orders:
+                stocks.append(order.symbol)
+        uniqueStocks = np.unique(stocks)
+        numStocks = len(uniqueStocks)
+
+        if numStocks == 0: # we have no trades
+            print("No trades were generated for this backtest")
+        else:
+            figStocks, axesStocks = plt.subplots(nrows=numStocks, ncols=1, 
+                                                 figsize=(9, 5 * numStocks))
+            # if there are multiple plots / rows then axes will be a list of Axes objects
+            # otherwise axes will just be an Axes object
+            # to keep things consistent I've made axes a list of Axes objects 
+            # (even when numStocks = 1)
+            if not isinstance(axesStocks, list):
+                axesStocks = [axesStocks]
+            
+            for i in range(len(axesStocks)):
+                ax, stock = axesStocks[i], uniqueStocks[i]
+                ax.plot(prices.index, prices[stock].values, color="blue")
+                ax.set_title("%s Trading" % stock, size=12)
+                if backtest.ordersDict is not None:
+                    ordersDict = backtest.ordersDict
+                    for timestamp in ordersDict.keys():
+                        orders = ordersDict[timestamp]
+                        for order in orders:
+                            if order.symbol == stock:
+                                tstamp = timestamp.to_pydatetime()
+                                direction = "B" if order.shares > 0 else "S"
+                                color = "g" if direction == "B" else "r"
+                                ax.plot(tstamp, prices[stock].loc[tstamp], "^", markersize=5, color=color)
+                
+            figStocks.tight_layout()
+    
     plt.show()
+        
+        

--- a/prophet/charting.py
+++ b/prophet/charting.py
@@ -58,12 +58,12 @@ def visualize_backtest(backtest):
             print("No trades were generated for this backtest")
         else:
             figStocks, axesStocks = plt.subplots(nrows=numStocks, ncols=1, 
-                                                 figsize=(9, 5 * numStocks))
-            # if there are multiple plots / rows then axes will be a list of Axes objects
+                                                 figsize=(9, 4 * numStocks))
+            # if there are multiple plots / rows then axes will be a array of Axes objects
             # otherwise axes will just be an Axes object
             # to keep things consistent I've made axes a list of Axes objects 
             # (even when numStocks = 1)
-            if not isinstance(axesStocks, list):
+            if not isinstance(axesStocks, np.ndarray):
                 axesStocks = [axesStocks]
             
             for i in range(len(axesStocks)):


### PR DESCRIPTION
The BackTest class now holds information on all orders (as a dict with timestamp keys) along with prices. These can then be passed to the visualise_backtest function in charting.py to annotate charts with buys and sells. 