### PR TITLE
Pandas and time zone (tz) info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.pytest_cache/
 *.py[cod]
 
 # C extensions

--- a/prophet/app.py
+++ b/prophet/app.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import pandas as pd
 
 from prophet.analyze import Analysis
 from prophet.portfolio import Portfolio
@@ -57,8 +58,10 @@ class Prophet(object):
             raise ProphetException("Must set an order generator by calling"
                                    "set_order_generator.")
 
-        timestamps = trading_days[(trading_days >= start) &
-                                  (trading_days <= end)]
+        start_utc = pd.to_datetime(start, utc=True)
+        end_utc = pd.to_datetime(end, utc=True)
+        timestamps = trading_days[(trading_days >= start_utc) &
+                                  (trading_days <= end_utc)]
         effective_start = timestamps[0]
 
         data = self._generate_data(start=effective_start,

--- a/prophet/data.py
+++ b/prophet/data.py
@@ -41,7 +41,7 @@ class PandasDataGenerator(DataGenerator):
                                                   data_path=data_path)
 
     def run(self, data, start, end, symbols, source, lookback=0):
-        data_start = self.get_data_start(start, lookback)
+        data_start = self.get_data_start(start, lookback).replace(tzinfo=None)
 
         # Current caching implementation based on Zipline
         symbols_data = dict()

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -33,10 +33,10 @@ def test_quickstart():
 
     prophet.register_portfolio_analyzers(default_analyzers)
     analysis = prophet.analyze_backtest(backtest)
-    assert round(analysis['sharpe'], 10) == 1.1083876014
-    assert round(analysis['average_return'], 10) == 0.0010655311
-    assert round(analysis['cumulative_return'], 10) == 2.2140809296
-    assert round(analysis['volatility'], 10) == 0.0152607097
+    assert round(analysis['sharpe'], 10) == 1.0967430073
+    assert round(analysis['average_return'], 10) == 0.0010501702
+    assert round(analysis['cumulative_return'], 10) == 2.1604345132
+    assert round(analysis['volatility'], 10) == 0.0152004028
 
     today = datetime(2014, 11, 10)
     expected_orders = Orders(Order(symbol='AAPL', shares=100))


### PR DESCRIPTION
Hi there.

The current version of pandas throws an error when comparing trading_days (with tz=UTC) to a standard python datetime with no tz info. Basically, it wants the time zone info to be consistent. I've added a few minor changes to make this work.

It also looks like the data coming back for the test file is slightly different. I've modified expected return values slightly, so have a quick look and let me know what you think. The tests should now be passing.

Pandas is also grumbling a touch about Panel => FutureWarning: Panel is deprecated and will be removed in a future version. Perhaps it'd be better to specify a particular pandas version in requirements.txt rather than pandas>=0.17.0... always tough with the Pandas deprecations.

Cheers,
Simon.

